### PR TITLE
Bump .NET version to .NET 10

### DIFF
--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -10,8 +10,8 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          6.0.x
-          8.0.x
+          10.0.x
+          10.0.x
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Create packages

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,8 +10,8 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          6.0.x
-          8.0.x
+          10.0.x
+          10.0.x
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Run tests

--- a/Content.Abstractions/Content.Abstractions.csproj
+++ b/Content.Abstractions/Content.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>

--- a/Content.ChatGpt/Content.ChatGpt.csproj
+++ b/Content.ChatGpt/Content.ChatGpt.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
     <Nullable>enable</Nullable>

--- a/Content.Claude/Content.Claude.csproj
+++ b/Content.Claude/Content.Claude.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net80</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
 		<Nullable>enable</Nullable>

--- a/Content.Memory/Content.Memory.csproj
+++ b/Content.Memory/Content.Memory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net60</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>

--- a/Content.Tests/Content.Tests.csproj
+++ b/Content.Tests/Content.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Staticsoft.$(MSBuildProjectName)</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Upgrades this repository from .NET 6/8 to **.NET 10** (`net10.0`).

**Changes:**
- Updated `TargetFramework(s)` in all project files to `net10.0`.
- Bumped the `setup-dotnet` version pin in CI workflows to `10.0.x`.

Builds cleanly against the .NET 10 SDK.